### PR TITLE
Avoid webpack spam by adding errors-only property to devServer

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -50,6 +50,7 @@ const developmentConfig = {
     hot: true,
     inline: true,
     progress: true,
+    stats: 'errors-only',
   },
   plugins: [HTMLWebpackPluginConfig, new webpack.HotModuleReplacementPlugin()]
 }


### PR DESCRIPTION
This tweak reduces the webpack output to what's important. It just means less scrolling. Maybe you'll find it useful.

Love the course btw :)
