### PR TITLE
add authUser to propTypes

### DIFF
--- a/app/containers/Authenticate/AuthenticateContainer.js
+++ b/app/containers/Authenticate/AuthenticateContainer.js
@@ -7,6 +7,7 @@ import * as userActionCreators from 'redux/modules/users'
 
 const AuthenticateContainer = React.createClass({
   propTypes: {
+    authUser: PropTypes.func.isRequired,
     fetchingUser: PropTypes.func.isRequired,
     fetchingUserFailure: PropTypes.func.isRequired,
     fetchingUserSuccess: PropTypes.func.isRequired,


### PR DESCRIPTION
Add the authUser (action creator) to propTypes for consistency.

Note: in the video tutorial (Video 12 - that has a link to this code) we parse all 4 action creators to propTypes - authUser, fetchingUser, fetchingUserFailure, and fetchingUserSuccess. The existing code for some reason has left out authUser - I can only suspect this was left out by accident.

Though not critical, this change will hopefully add a bit more documentation to the code.
